### PR TITLE
Fix SDL attaching to the wrong window

### DIFF
--- a/Ch3at/table.cpp
+++ b/Ch3at/table.cpp
@@ -264,7 +264,23 @@ BOOL CALLBACK enumWindowsCallback(HWND handle, LPARAM lParam) {
 bool isMainWindow(HWND handle) {
 	char windowTitle[256];
 	GetWindowTextA(handle, windowTitle, 256);
-	return GetWindow(handle, GW_OWNER) == (HWND)0 && IsWindowVisible(handle) && strstr(windowTitle, "RPCS3") == nullptr;
+	return (
+		GetWindow(handle, GW_OWNER) == (HWND)0 &&
+		IsWindowVisible(handle) &&
+		strstr(windowTitle, "RPCS3") == nullptr &&
+		isGameWindow((string)windowTitle)
+		);
+}
+
+bool isGameWindow(string windowTitle) {
+	const vector<string> validGameIds = { "BLES00760","BLJM60296","BLJM60437","BLJM61141","BLUS30464" };
+	for (string const& gameId : validGameIds) {
+		/* Check if the window title contains one of the valid game ID's for Skate 3*/
+		if (windowTitle.find(gameId) != string::npos) {
+			return true;
+		}
+	}
+	return false;
 }
 
 bool loadFont(const char* fontName, int size, TTF_Font* font) {

--- a/Ch3at/table.h
+++ b/Ch3at/table.h
@@ -93,6 +93,7 @@ void loadValues(HANDLE hProcess);
 HWND findMainWindow(unsigned long pid);
 BOOL CALLBACK enumWindowsCallback(HWND handle, LPARAM lParam);
 bool isMainWindow(HWND handle);
+bool isGameWindow(string titleString);
 void sdlWindow(unsigned long pid, HANDLE hProcess);
 void openFrozenTable();
 void loadValuesFrozen(HANDLE hProcess);


### PR DESCRIPTION
Fixes a bug that causes the CH3AT GUI (SDL) to attach to a utility window (RSX Debugger, Memory viewer...)
This is how it was before: 
![2021-02-11_16-01](https://user-images.githubusercontent.com/50383630/107708976-b9b57980-6cc4-11eb-99cd-de5c73edc526.png)

This patch makes it check for a valid game ID in the title of the window in addition to the checks that were already there before.